### PR TITLE
remove headers component from Boost find_package call

### DIFF
--- a/fhiclcpp/CMakeLists.txt
+++ b/fhiclcpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CetMake)
 
-find_package(Boost COMPONENTS headers REQUIRED EXPORT)
+find_package(Boost REQUIRED EXPORT)
 find_package(SQLite3 REQUIRED)
 find_package(TBB REQUIRED EXPORT)
 find_package(cetlib REQUIRED EXPORT)


### PR DESCRIPTION
The underlying cmake module knows that this is not a real component and issues a warning, but cetlibs find_package override elevates it to an error.