### PR TITLE
Match concept for declaration and implementation

### DIFF
--- a/fhiclcpp/coding.h
+++ b/fhiclcpp/coding.h
@@ -80,8 +80,7 @@ namespace fhicl::detail {
   ps_atom_t encode(std::complex<T> const&); // complex
   template <class T>
   ps_sequence_t encode(std::vector<T> const&); // sequence
-  template <class T>
-    requires(!std::is_arithmetic_v<T>)
+  template <non_numeric T>
   std::string encode(T const&); // none of the above
 
   // ----------------------------------------------------------------------


### PR DESCRIPTION
Of course, if `!std::is_arithmetic_v<T>` is better on both sides, then this can be easily adjusted.